### PR TITLE
Deno: autodetect languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ For an example of output, see the included French-English copy of
 That file is generated with the following command:
 
 ```sh
-deno run --allow-read deno/lib.ts fr en test/bovary.french.edited.txt test/bovary.english.edited.txt > test/bovary.aligned.html
+deno run --allow-read deno/lib.ts test/bovary.french.edited.txt test/bovary.english.edited.txt > test/bovary.aligned.html
 ```
 
-The command says "run the `lib.ts` script on a French source file and an English
+The command says "run the `lib.ts` script on Bovary in French (source) and Bovary in English (target)
 target file, which have the following paths."
 
 An example of a somewhat more liberal translation leading to poor alignment

--- a/deno.lock
+++ b/deno.lock
@@ -69,5 +69,40 @@
     "https://deno.land/x/esbuild_deno_loader@0.6.0/src/shared.ts": "b64749cd8c0f6252a11498bd8758ef1220003e46b2c9b68e16da63fd7e92b13a",
     "https://deno.land/x/importmap@0.2.1/_util.ts": "ada9a9618b537e6c0316c048a898352396c882b9f2de38aba18fd3f2950ede89",
     "https://deno.land/x/importmap@0.2.1/mod.ts": "ae3d1cd7eabd18c01a4960d57db471126b020f23b37ef14e1359bbb949227ade"
+  },
+  "npm": {
+    "specifiers": {
+      "franc-min@6.1.0": "franc-min@6.1.0",
+      "franc@6.1.0": "franc@6.1.0"
+    },
+    "packages": {
+      "collapse-white-space@2.1.0": {
+        "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+        "dependencies": {}
+      },
+      "franc-min@6.1.0": {
+        "integrity": "sha512-ZGKRCVw//1KvlLjeRjNTYB27Py6bq1J+0smr3IalQ4l7ZYR9DeoeLxjGWQKQ0Hr8n2dIjkfOvCzr7nzejljeJg==",
+        "dependencies": {
+          "trigram-utils": "trigram-utils@2.0.1"
+        }
+      },
+      "franc@6.1.0": {
+        "integrity": "sha512-woYqLX7sFcrKD4y1M33IorhH4b21bCDNr0Rm+zlAGRNuxLFilT4h8qEcclu8RFLpHmvNz7FgAYl9Vqfa8UZwoA==",
+        "dependencies": {
+          "trigram-utils": "trigram-utils@2.0.1"
+        }
+      },
+      "n-gram@2.0.2": {
+        "integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
+        "dependencies": {}
+      },
+      "trigram-utils@2.0.1": {
+        "integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
+        "dependencies": {
+          "collapse-white-space": "collapse-white-space@2.1.0",
+          "n-gram": "n-gram@2.0.2"
+        }
+      }
+    }
   }
 }

--- a/deno/main.test.ts
+++ b/deno/main.test.ts
@@ -21,3 +21,18 @@ Deno.test("run main", async () => {
   const expected = await readFixtureString("bovary.aligned.html");
   assertStrictEquals(result, expected.trim());
 });
+
+Deno.test("run main with language detection", async () => {
+  const bovaryFrench = fromFileUrl(
+    import.meta.resolve("../test/bovary.french.edited.txt"),
+  );
+  const bovaryEnglish = fromFileUrl(
+    import.meta.resolve("../test/bovary.english.edited.txt"),
+  );
+  const result = await go([
+    bovaryFrench,
+    bovaryEnglish,
+  ]);
+  const expected = await readFixtureString("bovary.aligned.html");
+  assertStrictEquals(result, expected.trim());
+});

--- a/deno/main.ts
+++ b/deno/main.ts
@@ -1,7 +1,8 @@
 import * as HunalignLib from "../resources/hunalign/web/hunalign.js";
-import { isLanguage, Language, languageCodes } from "../lib/types.ts";
+import { isLanguage, Language, language, languageCodes } from "../lib/types.ts";
 import { fromFileUrl } from "std/path/mod.ts";
 import { align, AlignmentConfig } from "../lib/align.ts";
+import { detectLang, isUnsupportedLanguage } from "../lib/detect-lang.ts";
 
 const USAGE = "[sourcelang] [targetlang] [sourcetext] [targettext]";
 const EXAMPLE =
@@ -19,21 +20,56 @@ async function main() {
   console.log(out);
 }
 
-export async function go(
-  [sourceLang, targetLang, sourceTextPath, targetTextPath]: string[],
-): Promise<string> {
-  if (!isLanguage(sourceLang)) {
-    console.error(`Invalid source language: ${sourceLang}`);
-    console.error(USAGE);
-    console.error(EXAMPLE);
-    Deno.exit(1);
-  }
+export async function go(args: string[]): Promise<string> {
+  let sourceLang: Language;
+  let targetLang: Language;
+  let sourceText: string;
+  let targetText: string;
+  if (args.length === 2) {
+    const [sourceTextPath, targetTextPath] = args;
+    sourceText = await Deno.readTextFile(sourceTextPath);
 
-  if (!isLanguage(targetLang)) {
-    console.error(`Invalid target language: ${targetLang}`);
-    console.error(USAGE);
-    console.error(EXAMPLE);
-    Deno.exit(1);
+    const detectedSourceLang = detectLang(sourceText);
+    if (isUnsupportedLanguage(detectedSourceLang)) {
+      console.error(`Unsupported source language: ${detectedSourceLang[1]}`);
+      console.error(USAGE);
+      console.error(EXAMPLE);
+      Deno.exit(1);
+    }
+    sourceLang = language[detectedSourceLang];
+
+    targetText = await Deno.readTextFile(targetTextPath);
+    const detectedTargetLang = detectLang(targetText);
+    if (isUnsupportedLanguage(detectedTargetLang)) {
+      console.error(`Unsupported target language: ${detectedTargetLang[1]}`);
+      console.error(USAGE);
+      console.error(EXAMPLE);
+      Deno.exit(1);
+    }
+    targetLang = language[detectedTargetLang];
+  } else if (args.length === 4) {
+    const [cmdSourceLang, cmdTargetLang, sourceTextPath, targetTextPath] = args;
+    if (!isLanguage(cmdSourceLang)) {
+      console.error(`Invalid source language: ${cmdSourceLang}`);
+      console.error(USAGE);
+      console.error(EXAMPLE);
+      Deno.exit(1);
+    }
+    sourceLang = cmdSourceLang;
+
+    if (!isLanguage(cmdTargetLang)) {
+      console.error(`Invalid target language: ${cmdTargetLang}`);
+      console.error(USAGE);
+      console.error(EXAMPLE);
+      Deno.exit(1);
+    }
+    targetLang = cmdTargetLang;
+    [sourceText, targetText] = await Promise.all([
+      Deno.readTextFile(sourceTextPath),
+      Deno.readTextFile(targetTextPath),
+    ]);
+  } else {
+    throw "Invalid number of arguments";
   }
 
   const [punktWasm, hunalignWasm] = await Promise.all([
@@ -41,11 +77,6 @@ export async function go(
     Deno.readFile(HUNALIGN_WASM_PATH),
   ]);
   const hunalignLib = await HunalignLib.Hunalign.create(hunalignWasm);
-
-  const [sourceText, targetText] = await Promise.all([
-    Deno.readTextFile(sourceTextPath),
-    Deno.readTextFile(targetTextPath),
-  ]);
 
   const [punktSourceTrainingData, punktTargetTrainingData] = await Promise.all([
     getTrainingData(sourceLang),

--- a/import_map.json
+++ b/import_map.json
@@ -2,6 +2,7 @@
   "imports": {
     "esbuild": "https://deno.land/x/esbuild@v0.17.18/mod.js",
     "esbuild_plugin_deno_loader": "https://deno.land/x/esbuild_deno_loader@0.7.0/mod.ts",
+    "franc": "npm:franc-min@6.1.0",
     "std/": "https://deno.land/std@0.185.0/",
     "xml": "https://deno.land/x/xml@2.1.1/mod.ts",
     "zod": "https://deno.land/x/zod@v3.21.4/mod.ts"

--- a/justfile
+++ b/justfile
@@ -23,6 +23,10 @@ lint:
 test:
     deno test --allow-read=./ --allow-run=./resources/punkt deno lib
 
+# write the sample alignments to the file system
+write-alignments:
+    deno run --allow-read=./ --allow-write=./ test/write-alignments.ts
+
 web-ci: web-install-deps web-check web-build
 
 web-install-deps:

--- a/lib/detect-lang.test.ts
+++ b/lib/detect-lang.test.ts
@@ -1,0 +1,34 @@
+import {LanguageName} from "./types.ts";
+import {assertEquals, assertStrictEquals} from "std/testing/asserts.ts";
+import {detectLang, unsupportedLanguage} from "./detect-lang.ts";
+
+Deno.test("detects English", () => {
+  const sample = "This is a sample text in English.";
+  testDetection(sample, "english");
+});
+
+Deno.test("detects French", () => {
+  const sample = "Ceci est un texte d'échantillon en français.";
+  testDetection(sample, "french");
+});
+
+Deno.test("detects Italian", () => {
+  const sample = "Questo è un testo di esempio in italiano.";
+  testDetection(sample, "italian");
+});
+
+Deno.test("detects Spanish", () => {
+  const sample = "Este es un texto de ejemplo en español.";
+  testDetection(sample, "spanish");
+});
+
+Deno.test("detects unsupported language", () => {
+  const sample = "滚滚长江东逝水";
+  const detected = detectLang(sample);
+  assertEquals(detected, unsupportedLanguage("und"));
+});
+
+function testDetection(text: string, expected: LanguageName) {
+  const detected = detectLang(text);
+  assertStrictEquals(detected, expected);
+}

--- a/lib/detect-lang.test.ts
+++ b/lib/detect-lang.test.ts
@@ -1,6 +1,14 @@
-import {LanguageName} from "./types.ts";
-import {assertEquals, assertStrictEquals} from "std/testing/asserts.ts";
-import {detectLang, unsupportedLanguage} from "./detect-lang.ts";
+import { LanguageName } from "./types.ts";
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+} from "std/testing/asserts.ts";
+import {
+  detectLang,
+  isUnsupportedLanguage,
+  unsupportedLanguage,
+} from "./detect-lang.ts";
 
 Deno.test("detects English", () => {
   const sample = "This is a sample text in English.";
@@ -26,9 +34,11 @@ Deno.test("detects unsupported language", () => {
   const sample = "滚滚长江东逝水";
   const detected = detectLang(sample);
   assertEquals(detected, unsupportedLanguage("und"));
+  assert(isUnsupportedLanguage(detected));
 });
 
 function testDetection(text: string, expected: LanguageName) {
   const detected = detectLang(text);
   assertStrictEquals(detected, expected);
+  assert(!isUnsupportedLanguage(detected));
 }

--- a/lib/detect-lang.ts
+++ b/lib/detect-lang.ts
@@ -1,0 +1,21 @@
+import { franc } from "franc";
+import { LanguageName } from "./types.ts";
+
+const $UNSUPPORTED_LANGUAGE = Symbol("UNSUPPORTED_LANGUAGE");
+type UnsupportedLanguage = [typeof $UNSUPPORTED_LANGUAGE, string];
+
+const supportedLanguages: Map<string, LanguageName> = new Map([
+  ["eng", "english"],
+  ["fra", "french"],
+  ["ita", "italian"],
+  ["spa", "spanish"],
+]);
+
+export function detectLang(text: string): LanguageName | UnsupportedLanguage {
+  const detected = franc(text);
+  return supportedLanguages.get(detected) || unsupportedLanguage(detected);
+}
+
+export function unsupportedLanguage(lang: string): UnsupportedLanguage {
+  return [$UNSUPPORTED_LANGUAGE, lang];
+}

--- a/lib/detect-lang.ts
+++ b/lib/detect-lang.ts
@@ -19,3 +19,10 @@ export function detectLang(text: string): LanguageName | UnsupportedLanguage {
 export function unsupportedLanguage(lang: string): UnsupportedLanguage {
   return [$UNSUPPORTED_LANGUAGE, lang];
 }
+
+export function isUnsupportedLanguage(l: unknown): l is UnsupportedLanguage {
+  return Array.isArray(l) &&
+    l.length === 2 &&
+    l[0] === $UNSUPPORTED_LANGUAGE &&
+    typeof l[1] === "string";
+}

--- a/test/write-alignments.ts
+++ b/test/write-alignments.ts
@@ -23,14 +23,10 @@ const MARIANELA_ALIGNED_PATH = fromFileUrl(
 
 async function main() {
   const bovary = await go([
-    "fr",
-    "en",
     BOVARY_FRENCH_PATH,
     BOVARY_ENGLISH_PATH,
   ]);
   const marianela = await go([
-    "es",
-    "en",
     MARIANELA_SPANISH_PATH,
     MARIANELA_ENGLISH_PATH,
   ]);

--- a/test/write-alignments.ts
+++ b/test/write-alignments.ts
@@ -1,4 +1,4 @@
-import { go } from "../deno/main.ts";
+import { goDetectingLanguages } from "../deno/main.ts";
 import { fromFileUrl } from "std/path/mod.ts";
 
 const BOVARY_FRENCH_PATH = fromFileUrl(
@@ -22,14 +22,14 @@ const MARIANELA_ALIGNED_PATH = fromFileUrl(
 );
 
 async function main() {
-  const bovary = await go([
+  const bovary = await goDetectingLanguages(
     BOVARY_FRENCH_PATH,
     BOVARY_ENGLISH_PATH,
-  ]);
-  const marianela = await go([
+  );
+  const marianela = await goDetectingLanguages(
     MARIANELA_SPANISH_PATH,
     MARIANELA_ENGLISH_PATH,
-  ]);
+  );
   await Promise.all([
     Deno.writeTextFile(BOVARY_ALIGNED_PATH, bovary),
     Deno.writeTextFile(MARIANELA_ALIGNED_PATH, marianela),


### PR DESCRIPTION
Eliminate the need to explicitly provide text languages on the command line: we use the `franc` lib to detect them.