### PR TITLE
use detected languages in worker

### DIFF
--- a/deno/main.ts
+++ b/deno/main.ts
@@ -112,8 +112,8 @@ async function goWithLanguagesAndText(
   )));
 
   const alignConfig: AlignmentConfig = {
-    sourceLanguage: languageCodes.get(sourceLang)!,
-    targetLanguage: languageCodes.get(targetLang)!,
+    sourceLang: languageCodes.get(sourceLang)!,
+    targetLang: languageCodes.get(targetLang)!,
     punktWasm,
     punktSourceTrainingData,
     punktTargetTrainingData,

--- a/lib/align.ts
+++ b/lib/align.ts
@@ -6,8 +6,8 @@ import { tokenizeWords } from "./tokenize-words.ts";
 import { LanguageName } from "./types.ts";
 
 export type AlignmentConfig = {
-  sourceLanguage: LanguageName;
-  targetLanguage: LanguageName;
+  sourceLang: LanguageName;
+  targetLang: LanguageName;
   punktWasm: Uint8Array;
   punktSourceTrainingData: Uint8Array;
   punktTargetTrainingData: Uint8Array;
@@ -146,8 +146,8 @@ export async function align(
   ).filter(([left, right]) => left.length > 0 && right.length > 0);
 
   return render(
-    conf.sourceLanguage,
-    conf.targetLanguage,
+    conf.sourceLang,
+    conf.targetLang,
     alignedParagraphs,
     alignedSentences,
   );

--- a/web/worker.ts
+++ b/web/worker.ts
@@ -2,9 +2,8 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="deno.worker" />
 import * as HunalignLib from "../resources/hunalign/web/hunalign.js";
-import { Language, language } from "../lib/types.ts";
+import { language, LanguageName } from "../lib/types.ts";
 import { align, AlignmentConfig } from "../lib/align.ts";
-import { detectLang, isUnsupportedLanguage } from "../lib/detect-lang.ts";
 
 // ensure async errors get handled just like sync errors
 self.onunhandledrejection = (e: PromiseRejectionEvent) => {
@@ -13,32 +12,30 @@ self.onunhandledrejection = (e: PromiseRejectionEvent) => {
 };
 
 self.onmessage = async (
-  e: MessageEvent<[string, string]>,
+  e: MessageEvent<[LanguageName, LanguageName, string, string]>,
 ) => {
-  const [source, target] = e.data;
-  const alignedHtml = await renderAlignment(source, target);
+  const [sourceLang, targetLang, source, target] = e.data;
+  const alignedHtml = await renderAlignment(
+    sourceLang,
+    targetLang,
+    source,
+    target,
+  );
   postMessage(alignedHtml);
 };
 
 async function renderAlignment(
+  sourceLang: LanguageName,
+  targetLang: LanguageName,
   source: string,
   target: string,
 ): Promise<string> {
-  const sourceLanguage = detectLang(source);
-  // TODO: handle this through messages rather than the error mechanism
-  if (isUnsupportedLanguage(sourceLanguage)) {
-    throw Error(`Unsupported source language: ${sourceLanguage[1]}`);
-  }
-  const targetLanguage = detectLang(target);
-  if (isUnsupportedLanguage(targetLanguage)) {
-    throw Error(`Unsupported target language: ${targetLanguage[1]}`);
-  }
-  const sourceLangCode = language[sourceLanguage];
-  const targetLangCode = language[targetLanguage];
+  const sourceLangCode = language[sourceLang];
+  const targetLangCode = language[targetLang];
 
   const [punktSourceTrainingData, punktTargetTrainingData] = await Promise.all([
-    getTrainingData(sourceLangCode),
-    getTrainingData(targetLangCode),
+    getTrainingData(sourceLang),
+    getTrainingData(targetLang),
   ]);
   const [punktWasm, hunalignWasm] = await Promise.all([
     fetchBinary(`punkt/punkt_bg.wasm`),
@@ -51,8 +48,8 @@ async function renderAlignment(
   );
 
   const alignConfig: AlignmentConfig = {
-    sourceLanguage,
-    targetLanguage,
+    sourceLang,
+    targetLang,
     punktWasm,
     punktSourceTrainingData,
     punktTargetTrainingData,
@@ -63,14 +60,7 @@ async function renderAlignment(
   return align(source, target, alignConfig);
 }
 
-function getTrainingData(l: Language): Promise<Uint8Array> {
-  const languageData: Map<Language, string> = new Map([
-    ["en", "english"],
-    ["fr", "french"],
-    ["it", "italian"],
-    ["es", "spanish"],
-  ]);
-  const languageName = languageData.get(l)!;
+function getTrainingData(languageName: LanguageName): Promise<Uint8Array> {
   const languageFileName = `${languageName}.json`;
   return fetchBinary(`punkt/data/${languageFileName}`);
 }


### PR DESCRIPTION
Don't redetect the languages in the worker. Saves space and time.