### PR TITLE
web: load main.js with defer

### DIFF
--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Bitextual is a tool for generating parallel, bilingual books from translated texts. It supports epubs.">
     <link rel="canonical" href="https://bitextual.net">
     <title>Bitextual: the bilingual book generator</title>
-    <script type="module" src="main.js" async></script>
+    <script type="module" src="main.js" defer></script>
     <style>
         html, body {
             margin: 0;


### PR DESCRIPTION
Was using async, but defer makes more sense since the script is DOM-dependent.