### PR TITLE
build for es2022

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,7 +9,7 @@
 		"build-index": "tsx tools/build-index.ts",
 		"build-sample": "tsx tools/build-sample.ts",
 		"build-static": "mkdir -p dist && cp -R static/* dist",
-		"build-worker": "esbuild src/worker.ts --bundle --minify --sourcemap --format=esm --external:module --outfile=dist/worker.js",
+		"build-worker": "esbuild src/worker.ts --bundle --minify --sourcemap --format=esm --external:module --target=es2022 --outfile=dist/worker.js",
 		"clean": "rm -rf build dist",
 		"typecheck": "npm run typecheck-lib && npm run typecheck-tools",
 		"typecheck-lib": "tsc",

--- a/packages/web/tools/build-index.ts
+++ b/packages/web/tools/build-index.ts
@@ -44,6 +44,7 @@ async function buildScript() {
 		sourcemap: true,
 		format: "esm",
 		write: false,
+		target: "es2022",
 		outdir,
 	});
 


### PR DESCRIPTION
keeps us safe when using some non-browser supported features like the "using" keyword