### PR TITLE
render width fix

### DIFF
--- a/packages/cf/test/aligned.html
+++ b/packages/cf/test/aligned.html
@@ -8,6 +8,11 @@
       line-height: 33px;
     }
 
+		table {
+			width: 100%;
+			table-layout: fixed;
+		}
+
     thead {
       position: sticky;
       top: 0;
@@ -25,9 +30,11 @@
     }
 
     td {
+			box-sizing: border-box;
       vertical-align: top;
       width: 50%;
       padding: 0 1em 1em;
+			word-wrap: break-word;
     }
 
     #swap-columns {
@@ -87,5 +94,5 @@
 
   document.getElementById("swap-columns").addEventListener("click", swapLangs);
   </script>
-  
+
 </body></html>

--- a/packages/cli/test/bovary.aligned.cli.html
+++ b/packages/cli/test/bovary.aligned.cli.html
@@ -10,6 +10,11 @@
       line-height: 33px;
     }
 
+    table {
+      width: 100%;
+      table-layout: fixed;
+    }
+
     thead {
       position: sticky;
       top: 0;
@@ -27,9 +32,11 @@
     }
 
     td {
+      box-sizing: border-box;
       vertical-align: top;
       width: 50%;
       padding: 0 1em 1em;
+      word-wrap: break-word;
     }
 
     #swap-columns {

--- a/packages/core/render.ts
+++ b/packages/core/render.ts
@@ -57,6 +57,11 @@ const TEMPLATE = `<!DOCTYPE html>
       line-height: 33px;
     }
 
+    table {
+      width: 100%;
+      table-layout: fixed;
+    }
+
     thead {
       position: sticky;
       top: 0;
@@ -74,9 +79,11 @@ const TEMPLATE = `<!DOCTYPE html>
     }
 
     td {
+      box-sizing: border-box;
       vertical-align: top;
       width: 50%;
       padding: 0 1em 1em;
+      word-wrap: break-word;
     }
 
     #swap-columns {


### PR DESCRIPTION
For an unknown reason, rendering of some books was resulting in the table expanding beyond 100% browser width. These CSS changes fix the issue.