### PR TITLE
Remove redundant console.log statements across the codebase.

### DIFF
--- a/packages/cf/functions/error.ts
+++ b/packages/cf/functions/error.ts
@@ -36,7 +36,6 @@ const onRequestPost: PagesFunction<Env> = async (context) => {
 	const city = request.cf?.city ?? "unknown";
 
 	const json = await request.json();
-	console.log("received error", json);
 	if (!Array.isArray(json)) {
 		return new Response("Bad Request: JSON must be an array", { status: 400 });
 	}
@@ -48,7 +47,6 @@ const onRequestPost: PagesFunction<Env> = async (context) => {
 		city,
 	];
 	const dp = { indexes: [], blobs, doubles: [] };
-	console.log("registering error", dp);
 	if (context.env.ERRORS === undefined) {
 		console.error("ERRORS is not defined");
 	} else {

--- a/packages/cf/functions/event.ts
+++ b/packages/cf/functions/event.ts
@@ -39,7 +39,6 @@ const onRequestPost: PagesFunction<Env> = async (context) => {
 	const city = request.cf?.city ?? "unknown";
 
 	const json = await request.json();
-	console.log("received event", json);
 	const event = await submitEventSchema.parseAsync(json);
 
 	const HEX_RADIX = 16;
@@ -59,7 +58,6 @@ const onRequestPost: PagesFunction<Env> = async (context) => {
 		event.format,
 	];
 	const dp = { indexes: [], blobs, doubles: [] };
-	console.log("registering event", dp);
 	if (context.env.EVENTS === undefined) {
 		console.error("EVENTS is not defined");
 	} else {

--- a/packages/web/src/main.ts
+++ b/packages/web/src/main.ts
@@ -174,8 +174,6 @@ function updateUI() {
 		submissionEnabled: sourceFile !== null && targetFile !== null && !loading,
 		submitButtonText: loading ? "Loading" : "View HTML",
 	};
-	console.log("updateUI", derivedState);
-	console.log("model", model);
 
 	errDiv.innerText = derivedState.error;
 	submitButton.disabled = !derivedState.submissionEnabled;

--- a/packages/web/src/worker.ts
+++ b/packages/web/src/worker.ts
@@ -26,7 +26,6 @@ async function renderAlignment(
 		epubToText(sourceData),
 		epubToText(targetData),
 	]);
-	console.log("got source text", sourceText.text.length);
 	const sourceLang = franc(sourceText.text);
 	const targetLang = franc(targetText.text);
 


### PR DESCRIPTION
This cleanup eliminates unnecessary debug logs from several files, including `worker.ts`, `error.ts`, `event.ts`, and `main.ts`. Reducing such logs improves code readability and minimizes noise in the console during runtime.