### PR TITLE
Remove unused `resolveJsonModule` from tsconfig files

### DIFF
--- a/packages/cf/functions/tsconfig.json
+++ b/packages/cf/functions/tsconfig.json
@@ -4,7 +4,6 @@
 	"compilerOptions": {
 		"module": "nodenext",
 		"noEmit": true,
-		"resolveJsonModule": true,
 		"types": ["@cloudflare/workers-types"]
 	},
 	"include": ["*.ts"]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,8 +3,7 @@
 	"extends": ["@tsconfig/strictest/tsconfig.json"],
 	"compilerOptions": {
 		"module": "nodenext",
-		"noEmit": true,
-		"resolveJsonModule": true
+		"noEmit": true
 	},
 	"include": ["**/*.ts"],
 	"exclude": ["*.test.ts"]

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -3,8 +3,7 @@
 	"extends": ["@tsconfig/strictest/tsconfig.json"],
 	"compilerOptions": {
 		"module": "nodenext",
-		"noEmit": true,
-		"resolveJsonModule": true
+		"noEmit": true
 	},
 	"include": ["**/*.ts"]
 }

--- a/packages/web-events/tsconfig.json
+++ b/packages/web-events/tsconfig.json
@@ -4,8 +4,7 @@
 	"compilerOptions": {
 		"module": "nodenext",
 		"noEmit": true,
-		"types": [],
-		"resolveJsonModule": true
+		"types": []
 	},
 	"include": ["*.ts"]
 }

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -4,8 +4,8 @@
 	"compilerOptions": {
 		"module": "nodenext",
 		"noEmit": true,
-		"resolveJsonModule": true,
-		"types": []
+		"types": [],
+		"resolveJsonModule": true
 	},
 	"include": ["src/*.ts"]
 }


### PR DESCRIPTION
The `resolveJsonModule` option was removed where it is unnecessary, streamlining the TypeScript configuration across packages. One exception was `packages/web/tsconfig.json`, where the order of options was adjusted but the option remains in use.