### PR TITLE
e2e: fix test async

### DIFF
--- a/packages/cf/e2e.test.ts
+++ b/packages/cf/e2e.test.ts
@@ -6,21 +6,8 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { fixturePath } from "@bitextual/test/util.js";
 import beautify from "js-beautify";
-import puppeteer, { type Browser, type Page } from "puppeteer";
+import puppeteer, { type Browser } from "puppeteer";
 import wranglerConf from "./wrangler.json" with { type: "json" };
-
-async function run() {
-	using _server = startServer();
-	const puppeteerP = startPuppeteer();
-	await waitForServer();
-	await using puppeteer = await puppeteerP;
-	const { browser } = puppeteer;
-
-	await Promise.all([
-		runIsolatedTest("404", browser, test404),
-		runIsolatedTest("alignment", browser, testAlignment),
-	]);
-}
 
 const SERVER_PORT = 8788;
 const BOVARY_FRENCH_EPUB_PATH = fixturePath("bovary.french.epub");
@@ -31,57 +18,76 @@ const __dirname = dirname(__filename);
 const DIST_PATH = resolve(__dirname, wranglerConf.pages_build_output_dir);
 const BASE_URL = new URL(`http://localhost:${SERVER_PORT}`).toString();
 const SERVER_LOG_LEVEL = "none";
-await run();
 
-async function testAlignment(page: Page) {
+let browser: Browser;
+let stopServer: () => void;
+test.before(async () => {
+	stopServer = startServer();
+	await waitForServer();
+	browser = await puppeteer.launch();
+	// for debugging, switch to this
+	// const browser = puppeteer.launch({ headless: false, slowMo: 250 });
+});
+test.after(async () => {
+	await browser.close();
+	stopServer();
+});
+
+test("404", async () => {
+	// TODO: replace with context manager
+	const context = await browser.createBrowserContext();
+	const page = await context.newPage();
+	try {
+		await page.goto(`${BASE_URL}/nonexistent`);
+
+		const pageHTML = await page.evaluate(() => document.body.innerHTML);
+		assert.equal(pageHTML, "404 Not Found\n");
+	} finally {
+		await page.close();
+		await context.close();
+	}
+});
+
+test("alignment", async () => {
 	const expectedPath = join(__dirname, "test", "aligned.html");
 	const expected = await readFile(expectedPath, "utf8");
 
-	await page.goto(BASE_URL);
+	const context = await browser.createBrowserContext();
+	const page = await context.newPage();
+	try {
+		await page.goto(BASE_URL);
 
-	const [sourceFileChooser] = await Promise.all([
-		page.waitForFileChooser(),
-		page.click("#sourceText"),
-	]);
-	await sourceFileChooser.accept([BOVARY_FRENCH_EPUB_PATH]);
+		const [sourceFileChooser] = await Promise.all([
+			page.waitForFileChooser(),
+			page.click("#sourceText"),
+		]);
+		await sourceFileChooser.accept([BOVARY_FRENCH_EPUB_PATH]);
 
-	const [targetFileChooser] = await Promise.all([
-		page.waitForFileChooser(),
-		page.click("#targetText"),
-	]);
-	await targetFileChooser.accept([BOVARY_ENGLISH_EPUB_PATH]);
+		const [targetFileChooser] = await Promise.all([
+			page.waitForFileChooser(),
+			page.click("#targetText"),
+		]);
+		await targetFileChooser.accept([BOVARY_ENGLISH_EPUB_PATH]);
 
-	await page.waitForFunction(
-		() => !document.querySelector<HTMLButtonElement>("#submit")?.disabled,
-	);
+		await page.waitForFunction(
+			() => !document.querySelector<HTMLButtonElement>("#submit")?.disabled,
+		);
 
-	await page.click("#submit");
+		await page.click("#submit");
 
-	await page.waitForFunction(
-		() => document.title === "bitextual: Madame Bovary",
-	);
-	const content = await page.content();
+		await page.waitForFunction(
+			() => document.title === "bitextual: Madame Bovary",
+		);
+		const content = await page.content();
 
-	const pageCanonical = canonicalizeHtml(content);
-	const expectedCanonical = canonicalizeHtml(expected);
-	assert.strictEqual(pageCanonical, expectedCanonical);
-}
-
-async function test404(page: Page) {
-	await page.goto(`${BASE_URL}/nonexistent`);
-
-	const pageHTML = await page.evaluate(() => document.body.innerHTML);
-	assert.equal(pageHTML, "404 Not Found\n");
-}
-
-async function startPuppeteer() {
-	const browser = await puppeteer.launch();
-
-	// for debugging, switch to this
-	// const browser = puppeteer.launch({ headless: false, slowMo: 250 });
-
-	return { browser, [Symbol.asyncDispose]: () => browser.close() };
-}
+		const pageCanonical = canonicalizeHtml(content);
+		const expectedCanonical = canonicalizeHtml(expected);
+		assert.strictEqual(pageCanonical, expectedCanonical);
+	} finally {
+		await page.close();
+		await context.close();
+	}
+});
 
 function startServer() {
 	const proc = spawn(
@@ -110,22 +116,7 @@ function startServer() {
 	const kill = () => process.kill(-pid, "SIGTERM");
 	process.on("SIGINT", kill);
 	process.on("SIGTERM", kill);
-	return { [Symbol.dispose]: kill };
-}
-
-async function runIsolatedTest(
-	name: string,
-	browser: Browser,
-	testFn: (page: Page) => Promise<void>,
-) {
-	const context = await browser.createBrowserContext();
-	const page = await context.newPage();
-	try {
-		await test(name, () => testFn(page));
-	} finally {
-		await page.close();
-		await context.close();
-	}
+	return kill;
 }
 
 /**


### PR DESCRIPTION
e2e tests were written in a way that made it easy for test contexts to get disposed before the tests themselves ran.